### PR TITLE
Apply fixes applied on the upstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ authors = ["CodeChain Team <hi@codechain.io>", "Parity Technologies <admin@parit
 elastic-array = "0.10"
 primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.git", version = "0.4" }
 rustc-hex = "1.0"
+
+[dev-dependencies]
+hex-literal = "0.2.1"

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -326,6 +326,7 @@ impl RlpStream {
         let len = self.buffer.len() - list.position;
         self.encoder().insert_list_payload(len, list.position);
         self.note_appended(1);
+        self.finished_list = true;
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -9,6 +9,8 @@
 
 extern crate primitives;
 extern crate rlp;
+#[macro_use]
+extern crate hex_literal;
 
 use std::{cmp, fmt};
 
@@ -479,4 +481,148 @@ fn rlp_stream_unbounded_list() {
     assert!(!stream.is_finished());
     stream.complete_unbounded_list();
     assert!(stream.is_finished());
+}
+
+#[test]
+fn test_rlp_is_int() {
+    for b in 0xb8..0xc0 {
+        let data: Vec<u8> = vec![b];
+        let rlp = Rlp::new(&data);
+        assert_eq!(rlp.is_int(), false);
+    }
+}
+
+/// test described in
+///
+/// https://github.com/paritytech/parity-common/issues/48
+#[test]
+fn test_inner_length_capping_for_short_lists() {
+    assert_eq!(
+        Rlp::new(&[0xc0, 0x82, b'a', b'b']).val_at::<String>(0),
+        Err(DecoderError::RlpIsTooShort {
+            expected: 1,
+            got: 0,
+        })
+    );
+    assert_eq!(
+        Rlp::new(&[0xc0 + 1, 0x82, b'a', b'b']).val_at::<String>(0),
+        Err(DecoderError::RlpIsTooShort {
+            expected: 1,
+            got: 0,
+        })
+    );
+    assert_eq!(
+        Rlp::new(&[0xc0 + 2, 0x82, b'a', b'b']).val_at::<String>(0),
+        Err(DecoderError::RlpIsTooShort {
+            expected: 1,
+            got: 0,
+        })
+    );
+    assert_eq!(Rlp::new(&[0xc0 + 3, 0x82, b'a', b'b']).val_at::<String>(0), Ok("ab".to_owned()));
+    assert_eq!(
+        Rlp::new(&[0xc0 + 4, 0x82, b'a', b'b']).val_at::<String>(0),
+        Err(DecoderError::RlpIsTooShort {
+            expected: 1,
+            got: 0,
+        })
+    );
+}
+
+#[test]
+fn non_canonical_string() {
+    assert_eq!(
+        Rlp::new(&[0xf7 + 1, 3, 0x80 + 2, b'a', b'b']).val_at::<String>(0),
+        Err(DecoderError::RlpInvalidIndirection)
+    );
+}
+
+#[test]
+fn test_canonical_string_encoding() {
+    assert_ne!(
+        Rlp::new(&[0xc0 + 4, 0xb7 + 1, 2, b'a', b'b']).val_at::<String>(0),
+        Rlp::new(&[0xc0 + 3, 0x82, b'a', b'b']).val_at::<String>(0)
+    );
+
+    assert_eq!(
+        Rlp::new(&[0xc0 + 4, 0xb7 + 1, 2, b'a', b'b']).val_at::<String>(0),
+        Err(DecoderError::RlpInvalidIndirection)
+    );
+}
+
+#[test]
+fn test_canonical_list_encoding() {
+    assert_ne!(
+        Rlp::new(&[0xc0 + 3, 0x82, b'a', b'b']).val_at::<String>(0),
+        Rlp::new(&[0xf7 + 1, 3, 0x82, b'a', b'b']).val_at::<String>(0)
+    );
+
+    assert_eq!(
+        Rlp::new(&[0xf7 + 1, 3, 0x82, b'a', b'b']).val_at::<String>(0),
+        Err(DecoderError::RlpInvalidIndirection)
+    );
+}
+
+// test described in
+//
+// https://github.com/paritytech/parity-common/issues/105
+#[test]
+fn test_nested_list_roundtrip() {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct Inner(u64, u64);
+
+    impl Encodable for Inner {
+        fn rlp_append(&self, s: &mut RlpStream) {
+            s.begin_unbounded_list().append(&self.0).append(&self.1).complete_unbounded_list();
+        }
+    }
+
+    impl Decodable for Inner {
+        fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+            Ok(Inner(rlp.val_at(0)?, rlp.val_at(1)?))
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct Nest<T>(Vec<T>);
+
+    impl<T: Encodable> Encodable for Nest<T> {
+        fn rlp_append(&self, s: &mut RlpStream) {
+            s.begin_unbounded_list().append_list(&self.0).complete_unbounded_list();
+        }
+    }
+
+    impl<T: Decodable> Decodable for Nest<T> {
+        fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+            Ok(Nest(rlp.list_at(0)?))
+        }
+    }
+
+
+    let items = (0..4).map(|i| Inner(i, i + 1)).collect();
+    let nest = Nest(items);
+
+    let encoded = rlp::encode(&nest);
+    let decoded = rlp::decode(&encoded).unwrap();
+
+    assert_eq!(nest, decoded);
+
+    let nest2 = Nest(vec![nest.clone(), nest]);
+
+    let encoded = rlp::encode(&nest2);
+    let decoded = rlp::decode(&encoded).unwrap();
+
+    assert_eq!(nest2, decoded);
+}
+
+// test described in
+//
+// https://github.com/paritytech/parity-ethereum/pull/9663
+#[test]
+fn test_list_at() {
+    let raw = hex!("f83e82022bd79020010db83c4d001500000000abcdef12820cfa8215a8d79020010db885a308d313198a2e037073488208ae82823a8443b9a355c5010203040531b9019afde696e582a78fa8d95ea13ce3297d4afb8ba6433e4154caa5ac6431af1b80ba76023fa4090c408f6b4bc3701562c031041d4702971d102c9ab7fa5eed4cd6bab8f7af956f7d565ee1917084a95398b6a21eac920fe3dd1345ec0a7ef39367ee69ddf092cbfe5b93e5e568ebc491983c09c76d922dc3");
+
+    let rlp = Rlp::new(&raw);
+    let _rlp1 = rlp.at(1).unwrap();
+    let rlp2 = rlp.at(2).unwrap();
+    assert_eq!(rlp2.val_at::<u16>(2).unwrap(), 33338);
 }


### PR DESCRIPTION
This patch includes
* Fix is_int() panic with untrusted input
    * https://github.com/paritytech/parity-common/commit/f27ee551f1a08d3824e6c03c1e00766ff796f5a2
* fix accepting malformed rlp packages, closes #48
    * https://github.com/paritytech/parity-common/commit/9c0d5263ea52606fd5fcc8ada49802d6a5605391
* fix accepting non-canonical rlp packages, closes #49
    * https://github.com/paritytech/parity-common/commit/4af0fa655863cf6ae6f946551f5400b5b86d871d
* fix rlp bug caused by incorrect offset calculation, introduced in #59
    * https://github.com/paritytech/parity-common/commit/90e230d746900590988a64ff1c5921fcec00ab3c
* fix nested unbounded lists (#203)
    * https://github.com/paritytech/parity-common/commit/a83e761430c6486fda979ec23c0f74017d9d7fe9