### PR TITLE
Replace ElasticArray with Vec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,5 @@ version = "0.3.0"
 authors = ["CodeChain Team <hi@codechain.io>", "Parity Technologies <admin@parity.io>"]
 
 [dependencies]
-elastic-array = "0.10"
 primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.git", version = "0.4" }
 rustc-hex = "1.0"

--- a/benches/rlp.rs
+++ b/benches/rlp.rs
@@ -103,3 +103,18 @@ fn bench_stream_1000_empty_lists(b: &mut Bencher) {
         let _ = stream.out();
     });
 }
+
+#[bench]
+fn bench_decode_1000_values(b: &mut Bencher) {
+    let mut stream = RlpStream::new_list(1000);
+    for _ in 0..1000 {
+        stream.append(&U256::from(1));
+    }
+    let data = stream.out();
+    b.iter(|| {
+        let rlp = Rlp::new(&data);
+        for i in 0..1000 {
+            let _: U256 = rlp.val_at(i).unwrap();
+        }
+    });
+}

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -7,6 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::iter::{empty, once};
 use std::{cmp, mem, str};
 
 use primitives::{H128, H160, H256, H512, H520, U256};
@@ -38,11 +39,11 @@ pub fn decode_usize(bytes: &[u8]) -> Result<usize, DecoderError> {
 
 impl Encodable for bool {
     fn rlp_append(&self, s: &mut RlpStream) {
-        if *self {
-            s.encoder().encode_value(&[1]);
+        s.encoder().encode_iter(once(if *self {
+            1u8
         } else {
-            s.encoder().encode_value(&[0]);
-        }
+            0
+        }));
     }
 }
 
@@ -129,9 +130,9 @@ where
 impl Encodable for u8 {
     fn rlp_append(&self, s: &mut RlpStream) {
         if *self != 0 {
-            s.encoder().encode_value(&[*self]);
+            s.encoder().encode_iter(once(*self));
         } else {
-            s.encoder().encode_value(&[]);
+            s.encoder().encode_iter(empty());
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,6 @@
 //! * You want to get view onto rlp-slice.
 //! * You don't want to decode whole rlp at once.
 
-extern crate elastic_array;
 extern crate primitives;
 extern crate rustc_hex;
 
@@ -43,7 +42,6 @@ mod rlpin;
 mod stream;
 mod traits;
 
-use elastic_array::ElasticArray1024;
 use std::borrow::Borrow;
 
 pub use error::DecoderError;
@@ -88,11 +86,11 @@ where
 ///
 /// fn main () {
 /// 	let animal = "cat";
-/// 	let out = rlp::encode(&animal).into_vec();
+/// 	let out = rlp::encode(&animal);
 /// 	assert_eq!(out, vec![0x83, b'c', b'a', b't']);
 /// }
 /// ```
-pub fn encode<E>(object: &E) -> ElasticArray1024<u8>
+pub fn encode<E>(object: &E) -> Vec<u8>
 where
     E: Encodable, {
     let mut stream = RlpStream::new();
@@ -100,7 +98,7 @@ where
     stream.drain()
 }
 
-pub fn encode_list<E, K>(object: &[K]) -> ElasticArray1024<u8>
+pub fn encode_list<E, K>(object: &[K]) -> Vec<u8>
 where
     E: Encodable,
     K: Borrow<E>, {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -7,7 +7,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use elastic_array::{ElasticArray1024, ElasticArray16};
 use std::borrow::Borrow;
 use traits::Encodable;
 
@@ -30,8 +29,8 @@ impl ListInfo {
 
 /// Appendable rlp encoder.
 pub struct RlpStream {
-    unfinished_lists: ElasticArray16<ListInfo>,
-    buffer: ElasticArray1024<u8>,
+    unfinished_lists: Vec<ListInfo>,
+    buffer: Vec<u8>,
     finished_list: bool,
 }
 
@@ -45,8 +44,8 @@ impl RlpStream {
     /// Initializes instance of empty `Stream`.
     pub fn new() -> Self {
         RlpStream {
-            unfinished_lists: ElasticArray16::new(),
-            buffer: ElasticArray1024::new(),
+            unfinished_lists: Vec::with_capacity(16),
+            buffer: Vec::with_capacity(1024),
             finished_list: false,
         }
     }
@@ -76,6 +75,30 @@ impl RlpStream {
         E: Encodable, {
         self.finished_list = false;
         value.rlp_append(self);
+        if !self.finished_list {
+            self.note_appended(1);
+        }
+        self
+    }
+
+    /// Appends iterator to the end of stream, chainable.
+    ///
+    /// ```rust
+    /// extern crate rlp;
+    /// use rlp::*;
+    ///
+    /// fn main () {
+    ///     let mut stream = RlpStream::new_list(2);
+    ///     stream.append(&"cat").append_iter("dog".as_bytes().iter().cloned());
+    ///     let out = stream.out();
+    ///     assert_eq!(out, vec![0xc8, 0x83, b'c', b'a', b't', 0x83, b'd', b'o', b'g']);
+    /// }
+    /// ```
+    pub fn append_iter<I>(&mut self, value: I) -> &mut Self
+    where
+        I: IntoIterator<Item = u8>, {
+        self.finished_list = false;
+        self.encoder().encode_iter(value);
         if !self.finished_list {
             self.note_appended(1);
         }
@@ -177,8 +200,8 @@ impl RlpStream {
         self
     }
 
-    /// Drain the object and return the underlying ElasticArray.
-    pub fn drain(self) -> ElasticArray1024<u8> {
+    /// Drain the object and return the underlying Vec.
+    pub fn drain(self) -> Vec<u8> {
         assert!(self.is_finished());
         self.buffer
     }
@@ -186,7 +209,7 @@ impl RlpStream {
     /// Appends raw (pre-serialised) RLP data. Use with caution. Chainable.
     pub fn append_raw(&mut self, bytes: &[u8], item_count: usize) -> &mut RlpStream {
         // push raw items
-        self.buffer.append_slice(bytes);
+        self.buffer.extend_from_slice(bytes);
 
         // try to finish and prepend the length
         self.note_appended(item_count);
@@ -267,7 +290,7 @@ impl RlpStream {
     /// 	assert_eq!(out, vec![0xc8, 0x83, b'c', b'a', b't', 0x83, b'd', b'o', b'g']);
     /// }
     pub fn is_finished(&self) -> bool {
-        self.unfinished_lists.len() == 0
+        self.unfinished_lists.is_empty()
     }
 
     /// Get raw encoded bytes
@@ -281,13 +304,12 @@ impl RlpStream {
     /// panic! if stream is not finished.
     pub fn out(self) -> Vec<u8> {
         assert!(self.is_finished());
-        // self.encoder.out().into_vec()
-        self.buffer.into_vec()
+        self.buffer
     }
 
     /// Try to finish lists
     fn note_appended(&mut self, inserted_items: usize) {
-        if self.unfinished_lists.len() == 0 {
+        if self.unfinished_lists.is_empty() {
             return
         }
 
@@ -330,7 +352,7 @@ impl RlpStream {
 }
 
 pub struct BasicEncoder<'a> {
-    buffer: &'a mut ElasticArray1024<u8>,
+    buffer: &'a mut Vec<u8>,
 }
 
 impl<'a> BasicEncoder<'a> {
@@ -345,7 +367,11 @@ impl<'a> BasicEncoder<'a> {
         let leading_empty_bytes = size.leading_zeros() as usize / 8;
         let size_bytes = 4 - leading_empty_bytes as u8;
         let buffer: [u8; 4] = size.to_be_bytes();
-        self.buffer.insert_slice(position, &buffer[leading_empty_bytes..]);
+
+        assert!(position <= self.buffer.len());
+        self.buffer.extend_from_slice(&buffer[leading_empty_bytes..]);
+        self.buffer[position..].rotate_right(size_bytes as usize);
+
         size_bytes as u8
     }
 
@@ -365,15 +391,35 @@ impl<'a> BasicEncoder<'a> {
 
     /// Pushes encoded value to the end of buffer
     pub fn encode_value(&mut self, value: &[u8]) {
-        match value.len() {
+        self.encode_iter(value.iter().cloned());
+    }
+
+    pub fn encode_iter<I>(&mut self, value: I)
+    where
+        I: IntoIterator<Item = u8>, {
+        let mut value = value.into_iter();
+        let len = match value.size_hint() {
+            (lower, Some(upper)) if lower == upper => lower,
+            _ => {
+                let value = value.collect::<Vec<_>>();
+                return self.encode_iter(value)
+            }
+        };
+
+        match len {
             // just 0
             0 => self.buffer.push(0x80u8),
-            // byte is its own encoding if < 0x80
-            1 if value[0] < 0x80 => self.buffer.push(value[0]),
-            // (prefix + length), followed by the string
             len @ 1..=55 => {
-                self.buffer.push(0x80u8 + len as u8);
-                self.buffer.append_slice(value);
+                let first = value.next().expect("iterator length is higher than 1");
+                if len == 1 && first < 0x80 {
+                    // byte is its own encoding if < 0x80
+                    self.buffer.push(first);
+                } else {
+                    // (prefix + length), followed by the string
+                    self.buffer.push(0x80u8 + len as u8);
+                    self.buffer.push(first);
+                    self.buffer.extend(value);
+                }
             }
             // (prefix + length of length), followed by the length, followd by the string
             len => {
@@ -381,7 +427,7 @@ impl<'a> BasicEncoder<'a> {
                 let position = self.buffer.len();
                 let inserted_bytes = self.insert_size(len, position);
                 self.buffer[position - 1] = 0xb7 + inserted_bytes;
-                self.buffer.append_slice(value);
+                self.buffer.extend(value);
             }
         }
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -8,7 +8,6 @@
 // except according to those terms.
 
 //! Common RLP traits
-use elastic_array::ElasticArray1024;
 use {DecoderError, Rlp, RlpStream};
 
 /// RLP decodable trait
@@ -23,7 +22,7 @@ pub trait Encodable {
     fn rlp_append(&self, s: &mut RlpStream);
 
     /// Get rlp-encoded bytes for this instance
-    fn rlp_bytes(&self) -> ElasticArray1024<u8> {
+    fn rlp_bytes(&self) -> Vec<u8> {
         let mut s = RlpStream::new();
         self.rlp_append(&mut s);
         s.drain()


### PR DESCRIPTION
ElasticArray doesn't help the performance in most cases.

before:
```
test bench_decode_1000_values        ... bench:      53,100 ns/iter (+/- 3,370)
test bench_decode_nested_empty_lists ... bench:         273 ns/iter (+/- 19)
test bench_decode_u256_value         ... bench:          26 ns/iter (+/- 2)
test bench_decode_u64_value          ... bench:          30 ns/iter (+/- 1)
test bench_stream_1000_empty_lists   ... bench:       9,574 ns/iter (+/- 624)
test bench_stream_nested_empty_lists ... bench:         213 ns/iter (+/- 4)
test bench_stream_u256_value         ... bench:         397 ns/iter (+/- 21)
test bench_stream_u64_value          ... bench:         116 ns/iter (+/- 9)
```

after:
```
test bench_decode_1000_values        ... bench:      52,146 ns/iter (+/- 1,851)
test bench_decode_nested_empty_lists ... bench:         278 ns/iter (+/- 9)
test bench_decode_u256_value         ... bench:          28 ns/iter (+/- 1)
test bench_decode_u64_value          ... bench:          25 ns/iter (+/- 1)
test bench_stream_1000_empty_lists   ... bench:       6,256 ns/iter (+/- 607)
test bench_stream_nested_empty_lists ... bench:          92 ns/iter (+/- 6)
test bench_stream_u256_value         ... bench:         316 ns/iter (+/- 19)
test bench_stream_u64_value          ... bench:          36 ns/iter (+/- 3)
```