### PR TITLE
Use v0.5.1 tag for codechain-primitives

### DIFF
--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["CodeChain Team <hi@codechain.io>", "Parity Technologies <admin@parit
 edition = "2018"
 
 [dependencies]
-primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.git", version = "0.5" }
+primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.git", version = "0.5", tag = "v0.5.1" }
 rustc-hex = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
If we don't specify the tag, Cargo uses the master branch and it will not work well.