### PR TITLE
Bump versions of compress and derive up as same as the main one

### DIFF
--- a/rlp-compress/Cargo.toml
+++ b/rlp-compress/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlp_compress"
-version = "0.3.0"
+version = "0.5.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/rlp-derive/Cargo.toml
+++ b/rlp-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlp_derive"
-version = "0.3.0"
+version = "0.5.0"
 authors = ["debris <marek.kotewicz@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
It is easy to maintain this repo with git tag.
And also, the similar crate `serde` is using this convention with its
derive crate.